### PR TITLE
Remove Redundant Assignment of brushWidth in changeBrushWidth Function

### DIFF
--- a/src/lib/components/Whiteboard/Whiteboard.jsx
+++ b/src/lib/components/Whiteboard/Whiteboard.jsx
@@ -246,7 +246,7 @@ const Whiteboard = ({
   function changeBrushWidth(e) {
     const intValue = parseInt(e.target.value);
     board.canvas.freeDrawingBrush.width = intValue;
-    const newOptions = { ...canvasDrawingSettings, brushWidth: intValue };
+    const newOptions = { ...canvasDrawingSettings };    
     setCanvasDrawingSettings(newOptions);
     onOptionsChange(newOptions, e, board.canvas);
   }


### PR DESCRIPTION
The issue pertains to the changeBrushWidth function within the Whiteboard component. Currently, this function both accepts a brushWidth parameter and retrieves the same value from the canvasDrawingSettings state, resulting in redundancy and code complexity. To address this, we propose simplifying the function by removing the redundant brushWidth assignment from the state, using the provided parameter directly. This change will enhance code clarity and reduce unnecessary complexity,