### PR TITLE
Limit sketch extent (create transparent walls)

### DIFF
--- a/src/lib/components/Whiteboard/Board.Class.js
+++ b/src/lib/components/Whiteboard/Board.Class.js
@@ -724,11 +724,8 @@ export class Board {
     // [Sketch range limits] Modified so that when the screen is reduced while reaching the end of the wall, it does not go beyond the border of the transparent wall that I set.
     if(scale < 1) {
       const newVpt = this.canvas.viewportTransform;
-      const x = this.axisLimit({ scale, vpt: this.nowX, axis: "x" });
-      const y = this.axisLimit({ scale, vpt: this.nowY, axis: "y" });
-
-      newVpt[4] = x;
-      newVpt[5] = y;
+      newVpt[4] = this.axisLimit({ scale, vpt: this.nowX, axis: "x" });
+      newVpt[5] = this.axisLimit({ scale, vpt: this.nowY, axis: "y" });
     }
   }
 

--- a/src/lib/components/Whiteboard/Board.Class.js
+++ b/src/lib/components/Whiteboard/Board.Class.js
@@ -690,7 +690,8 @@ export class Board {
     const drawingSettings = this.drawingSettings;
     drawingSettings.currentMode = '';
     canvas.isDrawingMode = false;
-
+    canvas.selection = true;
+    
     canvas.getObjects().map((item) => item.set({ selectable: true }));
     canvas.hoverCursor = 'all-scroll';
   }

--- a/src/lib/components/Whiteboard/Board.Class.js
+++ b/src/lib/components/Whiteboard/Board.Class.js
@@ -27,8 +27,23 @@ export class Board {
     viewportTransform: [1, 0, 0, 1, 0, 0],
   };
 
+  // [Sketch range limits]
+  nowX = 0
+  nowY = 0;
+  canvasRef
+  limitScale = 10;
+  sketchWidthLimit = 1920 * this.limitScale;
+  sketchHeightLimit = 1080 * this.limitScale;
+
   constructor(params) {
+    // [Sketch range limits]
+    const windowWidth = this.limitScale * (window.screen.width || window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth);
+    const windowHeight = this.limitScale * (window.screen.height || window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight);
+    this.sketchWidthLimit = (windowWidth > this.sketchWidthLimit) ? windowWidth : this.sketchWidthLimit;
+    this.sketchHeightLimit = (windowHeight > this.sketchHeightLimit) ? windowHeight : this.sketchHeightLimit;
+
     if (params) {
+      this.canvasRef = params.canvasRef;
       this.drawingSettings = params.drawingSettings;
     }
     this.canvas = this.initCanvas(this.canvasConfig);
@@ -89,7 +104,7 @@ export class Board {
     this.canvas.fire('config:chnage');
   }
 
-  addZoomListeners() {
+  addZoomListeners(params) {
     const canvas = this.canvas;
     const that = this;
     canvas.off('mouse:wheel');
@@ -108,6 +123,19 @@ export class Board {
         let vpt = canvas.viewportTransform;
         vpt[4] -= e.deltaX;
         vpt[5] -= e.deltaY;
+
+        try {
+          // [Sketch range limits]
+          const scale = params ? params.scale : 1;
+          vpt[4] = that.axisLimit({ scale, vpt: vpt[4], axis: "x" });
+          vpt[5] = that.axisLimit({ scale, vpt: vpt[5], axis: "y" });
+
+          // x, y coordinates used to zoom out the screen at the end of the wall (To prevent the screen from going beyond the border of the transparent wall I set when reducing the screen)
+          that.nowX = vpt[4];
+          that.nowY = vpt[5];
+        } catch (error) {
+          console.log(error);
+        }
 
         // const boundaries = that.getCanvasContentBoundaries();
 
@@ -175,6 +203,40 @@ export class Board {
         });
       }
     });
+  }
+
+  // [Sketch range limits]
+  axisLimit({ scale, vpt, axis }) {
+    let result = vpt;
+    const containerElement = this.canvasRef.current;
+    if (!containerElement) {
+      return vpt;
+    }
+
+    // Determined by whether it is the x-axis or y-axis
+    const containerSize = (axis === "x") ? containerElement.offsetWidth : containerElement.offsetHeight;  
+    const addScroll = (axis === "x") ? this.sketchWidthLimit : this.sketchHeightLimit;
+    
+    // Range adjustment when zooming in/out
+    const zoomInMinusValue = (containerSize * scale - (containerSize));
+    const zoomOutPlusValue = (containerSize * (1 - scale));
+    
+    // left || top
+    if (result > addScroll * scale) {
+      result = addScroll * scale;
+    }
+
+    // zoom in && right || zoom in && bottom
+    else if (scale >= 1 && result < -(addScroll * scale) - zoomInMinusValue) {
+      result = -(addScroll * scale) - zoomInMinusValue;
+    }
+
+    // zoom out && right || zoom out && bottom
+    else if (scale < 1 && result < -(addScroll * scale) + zoomOutPlusValue) {
+      result = -(addScroll * scale) + zoomOutPlusValue;
+    }
+
+    return result;
   }
 
   setDrawingSettings(drawingSettings) {
@@ -658,6 +720,16 @@ export class Board {
 
     this.canvas.zoomToPoint(point, scale);
     this.onZoom({ point, scale });
+
+    // [Sketch range limits] Modified so that when the screen is reduced while reaching the end of the wall, it does not go beyond the border of the transparent wall that I set.
+    if(scale < 1) {
+      const newVpt = this.canvas.viewportTransform;
+      const x = this.axisLimit({ scale, vpt: this.nowX, axis: "x" });
+      const y = this.axisLimit({ scale, vpt: this.nowY, axis: "y" });
+
+      newVpt[4] = x;
+      newVpt[5] = y;
+    }
   }
 
   resetZoom() {
@@ -670,7 +742,7 @@ export class Board {
   }
 
   onZoom(params) {
-    this.addZoomListeners();
+    this.addZoomListeners(params);
     this.canvas.fire('zoom:change', params);
   }
 

--- a/src/lib/components/Whiteboard/Whiteboard.jsx
+++ b/src/lib/components/Whiteboard/Whiteboard.jsx
@@ -148,6 +148,7 @@ const Whiteboard = ({
     const newBoard = new Board({
       drawingSettings: canvasDrawingSettings,
       canvasConfig: canvasConfig,
+      canvasRef: canvasRef,  // Sketch range limits
     });
 
     setBoard(newBoard);
@@ -310,6 +311,9 @@ const Whiteboard = ({
   function bringControlTOStartPosition() {
     board.canvas.viewportTransform = [1, 0, 0, 1, 0, 0];
     board.resetZoom(1);
+
+    board.nowX = 0;
+    board.nowY = 0;
   }
 
   function onFileChange(event) {


### PR DESCRIPTION
- Limit sketch extent (create transparent walls) 
- Fixed so that when I press the zoom out when touching the wall, it does not go beyond the range I set.

https://github.com/spiridonov-oa/react-whiteboard-pdf/assets/33927558/568685ba-b7e8-4424-a3ce-bb298dd99948

https://github.com/spiridonov-oa/react-whiteboard-pdf/assets/33927558/fa956fa3-9686-4308-8e08-3446d0bac864

